### PR TITLE
añadiendo código de ejemplo para clusters con clasificación

### DIFF
--- a/docs/ejemplos/cluster.md
+++ b/docs/ejemplos/cluster.md
@@ -113,8 +113,51 @@
             />
         </DaiMapa>
 </DaiTarjetaContenedorMapa>
-````
+```
 
 ## Cluster con tamaños, desde las reglas de clasificacion
 
 <cluster-4-cluster-clasificado />
+
+```html
+<template>
+    <DaiTarjetaContenedorMapa>
+        <template #header>
+            
+            <DaiLeyendaMapa :para="['cluster-clasificado','sin-cluster']"/>
+        </template>
+        <DaiMapa>
+            <DaiCapaXyz />
+            <DaiCapaGeojson 
+            id="sin-cluster"
+            titulo="Capa sin cluster"
+            :url="$withBase('/centroides-estados.geojson')"
+            :estilo-capa="{
+                circle:{
+                    fill:{color:'white'},
+                    stroke:{color:'black',width:1},
+                    radius:4
+                }
+            }"
+            />
+            <DaiCapaGeojsonCluster 
+            id="cluster-clasificado"
+            titulo="Capa con cluster"
+            :url="$withBase('/centroides-estados.geojson')"
+            :reglas-estilo-capa="{
+                clasificacion:'linear',
+                columna:'features_count',
+                propiedadObjetivo: 'proporcion',
+                clases:4,
+                proporciones:[4,8,12,16]
+            }"
+            :estilo-capa="{
+                circle:{
+                    fill:{color:'green'}
+                }
+            }"
+            />
+        </DaiMapa>
+    </DaiTarjetaContenedorMapa>
+</template>
+```


### PR DESCRIPTION
La documentación de los clústers [Cluster con tamaños, desde las reglas de clasificacion](https://github.com/conacyt-dai/dai-maps/blob/main/docs/ejemplos/cluster.md#cluster-con-tama%C3%B1os-desde-las-reglas-de-clasificacion) no contaba con el fragmento de código que muestra cómo se realizó el ejemplo

Con este cambio, la sección en dónde se encuentra el ejemplo quedaría de la siguiente forma:

![imagen](https://user-images.githubusercontent.com/47924469/181396344-b34beb7f-2f10-4d5c-bc0e-5f02a887ea02.png)
